### PR TITLE
Drop dependency on ansible (six.moves)

### DIFF
--- a/aur.py
+++ b/aur.py
@@ -2,8 +2,7 @@
 
 from ansible.module_utils.basic import *
 import json
-from ansible.module_utils import six
-from six.moves import urllib
+import urllib.request
 import tarfile
 import os
 import os.path


### PR DESCRIPTION
As it is, aur.py depends on ansible being installed on the target host. So, you would need to get ansible installed in your target host just to be able to make use of aur.py and install whatever packages you need.

Let's review the dependency:

      from ansible.module_utils import six from six.moves import urllib

I reckon that the six¹ package is there to isolate an ansible module's code from the particular major version of python being used (2 or 3).

Fortunately, since last week², the ansible package in archlinux now depends directly on python3, so I reckon that in this particular instance, we can safely import urllib.request directly, which from now on will be spot on.

To recap, current arch ships python3, and the arch ansible package depends on it to run. aur.py's purpose is to run on archlinux hosts, thus, python3 can be safely assumed to be available. So we can depend directly on it and relax the dependency on ansible itself.

On a personal note, I am using this nice module to help me bootstrap my arch systems, so not having to install ansible just to be able to use it makes my day a little better :-)

Thanks a bunch!

[Feel free to edit the commit log]

[1]: https://pythonhosted.org/six/ [2]: https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/ansible&id=bb1a1cc822891387d5a8b3dad0d0ccdee94c0c51