### PR TITLE
README.md: Add missing .py suffix in setup instructions and misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ makepkg will be used if no helper was found or if it's specified explicitly.
 The [aur-ansible-git](https://aur.archlinux.org/packages/ansible-aur-git) package is available in the AUR.
 Note the module is installed in `/usr/share/ansible/plugins/modules` which is one of the default module library paths.
 
-### Manual installation 
+### Manual installation
 1. Clone the *ansible-aur* repository in your playbook custom-module directory:
 ```
 mkdir --parents library

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note the module is installed in `/usr/share/ansible/plugins/modules` which is on
 ### Manual installation
 1. Clone the *ansible-aur* repository in your playbook custom-module directory:
 ```
-mkdir --parents library
+mkdir library
 cd library
 git clone git@github.com:kewlfft/ansible-aur.git
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note the module is installed in `/usr/share/ansible/plugins/modules` which is on
 ```
 mkdir library
 cd library
-git clone git@github.com:kewlfft/ansible-aur.git
+git clone https://github.com/kewlfft/ansible-aur.git
 ```
 
 2. Link the script `library/ansible-aur/aur.py` to `library/aur.py`:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ cd library
 git clone git@github.com:kewlfft/ansible-aur.git
 ```
 
-2. Link the script `library/ansible-aur/aur.py` to `library/aur`:
+2. Link the script `library/ansible-aur/aur.py` to `library/aur.py`:
 ```
-ln --symbolic ansible-aur/aur.py aur
+ln --symbolic ansible-aur/aur.py aur.py
 ```
 
 ## Usage


### PR DESCRIPTION
Tried without the .py just in case, and it doesn't work.