### PR TITLE
README.md: Simplify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,9 @@ The [aur-ansible-git](https://aur.archlinux.org/packages/ansible-aur-git) packag
 Note the module is installed in `/usr/share/ansible/plugins/modules` which is one of the default module library paths.
 
 ### Manual installation
-1. Clone the *ansible-aur* repository in your playbook custom-module directory:
+Just clone the *ansible-aur* repository into your user custom-module directory:
 ```
-mkdir library
-cd library
-git clone https://github.com/kewlfft/ansible-aur.git
-```
-
-2. Link the script `library/ansible-aur/aur.py` to `library/aur.py`:
-```
-ln --symbolic ansible-aur/aur.py aur.py
+git clone https://github.com/kewlfft/ansible-aur.git ~/.ansible/plugins/modules/aur
 ```
 
 ## Usage


### PR DESCRIPTION
It turns out that the best way to deploy a custom module repo is on `~/.ansible/plugins/modules`. For one, there is no need to symlink the `module.py` file, and also ansible-doc finds it without having to specify the path to the module via the `-M` switch.