### PR TITLE
Make skip_installed an enum instead of boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ makepkg will be used if no helper was found or if it's specified explicitly.
 - [makepkg](https://wiki.archlinux.org/index.php/makepkg)
 
 ## Options
-|parameter      |required |default |choices                                            |comments|
-|---            |---      |---     |---                                                |---|
-|name           |no       |        |                                                   |Name or list of names of the package(s) to install or upgrade.|
-|upgrade        |no       |no      |yes, no                                            |Whether or not to upgrade whole system.|
-|use            |no       |auto    |auto, aurman, pacaur, trizen, pikaur, yay, makepkg |The helper to use, 'auto' uses the first known helper found and makepkg as a fallback.|
-|skip_installed |no       |no      |yes, no                                            |Skip operations if the package is present.|
-|skip_pgp_check |no       |no      |yes, no                                            |Skip verification of PGP signatures. This is useful when installing packages on a host without GnuPG (properly) configured. Only valid with makepkg.|
+|parameter      |required |default |choices                                             |comments|
+|---            |---      |---      |---                                                |---|
+|name           |no       |         |                                                   |Name or list of names of the package(s) to install or upgrade.|
+|upgrade        |no       |no       |yes, no                                            |Whether or not to upgrade whole system.|
+|use            |no       |auto     |auto, aurman, pacaur, trizen, pikaur, yay, makepkg |The helper to use, 'auto' uses the first known helper found and makepkg as a fallback.|
+|skip_installed |no       |versioned|all, versioned, none                               |Skip operations if the package is present. Choosing versioned will all you to skip non-VCS (-git, -hg, etc.) packages.|
+|skip_pgp_check |no       |no       |yes, no                                            |Skip verification of PGP signatures. This is useful when installing packages on a host without GnuPG (properly) configured. Only valid with makepkg.|
 
 ### Note
 * Either *name* or *upgrade* is required, both cannot be used together.
@@ -45,7 +45,7 @@ git clone https://github.com/kewlfft/ansible-aur.git ~/.ansible/plugins/modules/
 Use it in a task, as in the following examples:
 ```
 # Install trizen using makepkg, skip if trizen is already installed
-- aur: name=trizen use=makepkg skip_installed=true
+- aur: name=trizen use=makepkg skip_installed=all
   become: yes
   become_user: aur_builder
 


### PR DESCRIPTION
With these changes skip_installed allows you to skip 'all', 'versioned' (non-vcs) or 'none'

Fixes #9