### PR TITLE
Aurman feature: fetch new pgp keys without interaction

### DIFF
--- a/aur.py
+++ b/aur.py
@@ -72,7 +72,7 @@ EXAMPLES = '''
 def_lang = ['env', 'LC_ALL=C']
 
 use_cmd = {
-    'aurman': ['aurman', '-S', '--noconfirm', '--noedit', '--needed', '--skip_news'],
+    'aurman': ['aurman', '-S', '--noconfirm', '--noedit', '--needed', '--skip_news', '--pgp_fetch'],
     'yay': ['yay', '-S', '--noconfirm', '--needed'],
     'pacaur': ['pacaur', '-S', '--noconfirm', '--noedit', '--needed'],
     'trizen': ['trizen', '-S', '--noconfirm', '--noedit', '--needed'],


### PR DESCRIPTION
[aurman](https://github.com/polygamma/aurman) has a feature pgp_fetch which fetches the needed PGP keys without asking.

I stumbled multiple times on this one and was wondering if it could be implemented as default?