### PR TITLE
Feature: use the skip_new_locations option for aurman wrapper

### DIFF
--- a/aur.py
+++ b/aur.py
@@ -76,7 +76,7 @@ EXAMPLES = '''
 def_lang = ['env', 'LC_ALL=C']
 
 use_cmd = {
-    'aurman': ['aurman', '-S', '--noconfirm', '--noedit', '--needed', '--skip_news', '--pgp_fetch'],
+    'aurman': ['aurman', '-S', '--noconfirm', '--noedit', '--needed', '--skip_news', '--pgp_fetch', '--skip_new_locations'],
     'yay': ['yay', '-S', '--noconfirm', '--needed'],
     'pacaur': ['pacaur', '-S', '--noconfirm', '--noedit', '--needed'],
     'trizen': ['trizen', '-S', '--noconfirm', '--noedit', '--needed'],


### PR DESCRIPTION
Aurman has this feature called skip_new_locations which skips the current failures on ansible runs when packages are moved to other locations which gets an informal message waiting on a yes reply where the default answers with no.