### PR TITLE
makepkg: Check for "fakeroot" binary

### DIFF
--- a/aur.py
+++ b/aur.py
@@ -125,6 +125,7 @@ def install_with_makepkg(module, package):
     """
     Install the specified package with makepkg
     """
+    module.get_bin_path('fakeroot', required=True)
     f = open_url('https://aur.archlinux.org/rpc/?v=5&type=info&arg={}'.format(package))
     result = json.loads(f.read().decode('utf8'))
     if result['resultcount'] != 1:


### PR DESCRIPTION
Get  an nice error message:
```
fatal: [bitzer]: FAILED! => {"changed": false, "msg": "Failed to find required executable fakeroot in paths: /usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/usr/sbin"}
```

instead of python backtrace when the `fakeroot` package is missing on the host:

```
TASK [Install Caddy] **********************************************************************************************************
 [WARNING]: Module invocation had junk after the JSON data: Traceback (most recent call last):   File
"/tmp/ansible_aur_payload_7aleiaaw/__main__.py", line 146, in install_with_makepkg   File
"/tmp/ansible_aur_payload_7aleiaaw/ansible_aur_payload.zip/ansible/module_utils/basic.py", line 2905, in run_command   File
"/tmp/ansible_aur_payload_7aleiaaw/ansible_aur_payload.zip/ansible/module_utils/basic.py", line 2367, in fail_json SystemExit:
1  During handling of the above exception, another exception occurred:  Traceback (most recent call last):   File
"/home/juergen/.ansible/tmp/ansible-tmp-1540914487.165589-20857247627051/AnsiballZ_aur.py", line 113, in <module>
_ansiballz_main()   File "/home/juergen/.ansible/tmp/ansible-tmp-1540914487.165589-20857247627051/AnsiballZ_aur.py", line 105,
in _ansiballz_main     invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)   File "/home/juergen/.ansible/tmp/ansible-
tmp-1540914487.165589-20857247627051/AnsiballZ_aur.py", line 48, in invoke_module     imp.load_module('__main__', mod, module,
MOD_DESC)   File "/usr/lib/python3.7/imp.py", line 234, in load_module     return load_source(name, filename, file)   File
"/usr/lib/python3.7/imp.py", line 169, in load_source     module = _exec(spec, sys.modules[name])   File "<frozen
importlib._bootstrap>", line 630, in _exec   File "<frozen importlib._bootstrap_external>", line 728, in exec_module   File
"<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed   File
``` 