### PR TITLE
Disable compression

### DIFF
--- a/aur.py
+++ b/aur.py
@@ -144,7 +144,7 @@ def install_with_makepkg(module, package):
         os.chdir(format(result['Name']))
         if module.params['skip_pgp_check']:
             use_cmd['makepkg'].append('--skippgpcheck')
-        rc, out, err = module.run_command(use_cmd['makepkg'], check_rc=True)
+        rc, out, err = module.run_command(use_cmd['makepkg'], environ_update={'PKGEXT': 'pkg.tar'}, check_rc=True)
         os.chdir(current_path)
     return (rc, out, err)
 

--- a/aur.py
+++ b/aur.py
@@ -129,7 +129,7 @@ def install_with_makepkg(module, package):
     f = open_url('https://aur.archlinux.org/rpc/?v=5&type=info&arg={}'.format(package))
     result = json.loads(f.read().decode('utf8'))
     if result['resultcount'] != 1:
-        return (1, '', 'package not found')
+        return (1, '', 'package %s not found' % (package))
     result = result['results'][0]
     f = open_url('https://aur.archlinux.org/{}'.format(result['URLPath']))
     current_path = os.getcwd()


### PR DESCRIPTION
This speeds up the installation a lot: aur installation only takes half the time in my tests.