### PR TITLE
Add use_args option for explicit helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following helpers are supported and automatically selected, if present, in t
 |name           |                                                       |Name or list of names of the package(s) to install or upgrade.|
 |state          |**present**, latest                                    |Desired state of the package, 'present' skips operations if the package is already installed.|
 |upgrade        |yes, **no**                                            |Whether or not to upgrade whole system.|
-|use            |**auto**, yay, pacaur, trizen, pikaur, aurman, makepkg |The helper to use, 'auto' uses the first known helper found and makepkg as a fallback.|
+|use            |**auto**, yay, pacaur, trizen, pikaur, aurman, makepkg |The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.|
 |use_args       |[]                                                     |A list of arguments to pass directly to the used tool. Cannot be used unless use is set to something other than 'auto'.|
 |aur_only       |yes, **no**                                            |Limit helper operation to the AUR.|
 |skip_pgp_check |yes, **no**                                            |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured. Cannot be used unless use is set to something other than 'auto'.|

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The following helpers are supported and automatically selected, if present, in t
 |use            |**auto**, yay, pacaur, trizen, pikaur, aurman, makepkg |The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.|
 |use_args       |[]                                                     |A list of arguments to pass directly to the used tool. Cannot be used unless use is set to something other than 'auto'.|
 |aur_only       |yes, **no**                                            |Limit helper operation to the AUR.|
-|skip_pgp_check |yes, **no**                                            |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured. Cannot be used unless use is set to something other than 'auto'.|
-|ignore_arch    |yes, **no**                                            |Only valid with makepkg. Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field. Cannot be used unless use is set to something other than 'auto'.|
+|skip_pgp_check |yes, **no**                                            |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured. Cannot be used unless use is set to 'makepkg'.|
+|ignore_arch    |yes, **no**                                            |Only valid with makepkg. Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field. Cannot be used unless use is set to 'makepkg'.|
 
 ### Note
 * Either *name* or *upgrade* is required, both cannot be used together.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ The following helpers are supported and automatically selected, if present, in t
 
 ## Options
 |Parameter      |Choices/**Default**                                    |Comments|
-|---            |---                                                |---|
-|name           |                                                   |Name or list of names of the package(s) to install or upgrade.|
+|---            |---                                                    |---|
+|name           |                                                       |Name or list of names of the package(s) to install or upgrade.|
 |state          |**present**, latest                                    |Desired state of the package, 'present' skips operations if the package is already installed.|
 |upgrade        |yes, **no**                                            |Whether or not to upgrade whole system.|
 |use            |**auto**, yay, pacaur, trizen, pikaur, aurman, makepkg |The helper to use, 'auto' uses the first known helper found and makepkg as a fallback.|
+|use_args       |[]                                                     |A list of arguments to pass directly to the used tool. Cannot be used unless use is set to something other than 'auto'.|
 |aur_only       |yes, **no**                                            |Limit helper operation to the AUR.|
-|skip_pgp_check |yes, **no**                                            |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured.|
-|ignore_arch    |yes, **no**                                            |Only valid with makepkg. Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field.|
+|skip_pgp_check |yes, **no**                                            |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured. Cannot be used unless use is set to something other than 'auto'.|
+|ignore_arch    |yes, **no**                                            |Only valid with makepkg. Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field. Cannot be used unless use is set to something other than 'auto'.|
 
 ### Note
 * Either *name* or *upgrade* is required, both cannot be used together.

--- a/library/aur.py
+++ b/library/aur.py
@@ -34,6 +34,7 @@ options:
     upgrade:
         description:
             - Whether or not to upgrade whole system.
+        default: no
         type: bool
 
     use:

--- a/library/aur.py
+++ b/library/aur.py
@@ -39,7 +39,7 @@ options:
 
     use:
         description:
-            - The helper to use, 'auto' uses the first known helper found and makepkg as a fallback.
+            - The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.
         default: auto
         choices: [ auto, yay, pacaur, trizen, pikaur, aurman, makepkg ]
 
@@ -272,7 +272,7 @@ def make_module():
     params = module.params
 
     if params['use'] == 'auto' and params['use_args']:
-        module.fail_json(msg="You must specify a helper other than 'auto' to use the 'use_flags' option.")
+        module.fail_json(msg="You must specify a tool other than 'auto' to use the 'use_flags' option.")
 
     if params['use'] != 'makepkg' and params['skip_pgp_check']:
         module.fail_json(msg="You must use 'makepkg' to use the 'skip_pgp_check' option.")
@@ -290,7 +290,7 @@ def make_module():
         use = params['use']
 
     if params.get('upgrade', False) and use == 'makepkg':
-        module.fail_json(msg="Upgrade cannot be used with the helper 'makepkg'.")
+        module.fail_json(msg="Upgrade cannot be used with the tool 'makepkg'.")
 
     return module, use
 

--- a/library/aur.py
+++ b/library/aur.py
@@ -218,7 +218,7 @@ def install_packages(module, packages, use, state, aur_only):
     )
 
 
-def main():
+def make_module():
     module = AnsibleModule(
         argument_spec={
             'name': {
@@ -274,12 +274,23 @@ def main():
     if params.get('upgrade', False) and use == 'makepkg':
         module.fail_json(msg="Upgrade cannot be used with the helper 'makepkg'.")
 
+    return module, use
+
+
+def apply_module(module, use):
+    params = module.params
+
     if module.check_mode:
         check_packages(module, params['name'])
     elif params.get('upgrade', False):
         upgrade(module, use, params['aur_only'])
     else:
         install_packages(module, params['name'], use, params['state'], params['aur_only'])
+
+
+def main():
+    module, use = make_module()
+    apply_module(module, use)
 
 
 if __name__ == '__main__':

--- a/library/aur.py
+++ b/library/aur.py
@@ -56,6 +56,7 @@ options:
             - Only valid with makepkg.
               Skip PGP signatures verification of source file.
               This is useful when installing packages without GnuPG (properly) configured.
+              Cannot be used unless use is set to 'makepkg'.
         type: bool
         default: no
 
@@ -63,6 +64,7 @@ options:
         description:
             - Only valid with makepkg.
               Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field.
+              Cannot be used unless use is set to 'makepkg'.
         type: bool
         default: no
 

--- a/library/aur.py
+++ b/library/aur.py
@@ -146,7 +146,7 @@ def check_packages(module, packages):
     module.exit_json(changed=status, msg=message, diff=diff)
 
 
-def install_with_makepkg(module, package, skip_pgp_check, ignore_arch):
+def install_with_makepkg(module, package, use_args, skip_pgp_check, ignore_arch):
     """
     Install the specified package with makepkg
     """
@@ -161,7 +161,7 @@ def install_with_makepkg(module, package, skip_pgp_check, ignore_arch):
         tar = tarfile.open(mode='r|*', fileobj=f)
         tar.extractall(tmpdir)
         tar.close()
-        command = build_command_prefix('makepkg', [], skip_pgp_check=skip_pgp_check, ignore_arch=ignore_arch)
+        command = build_command_prefix('makepkg', use_args, skip_pgp_check=skip_pgp_check, ignore_arch=ignore_arch)
         rc, out, err = module.run_command(command, cwd=os.path.join(tmpdir, result['Name']), check_rc=True)
     return (rc, out, err)
 
@@ -213,7 +213,7 @@ def install_packages(module, packages, use, use_args, state, skip_pgp_check, ign
                 rc = 0
                 continue
         if use == 'makepkg':
-            rc, out, err = install_with_makepkg(module, package, skip_pgp_check, ignore_arch)
+            rc, out, err = install_with_makepkg(module, package, use_args, skip_pgp_check, ignore_arch)
         else:
             command = build_command_prefix(use, use_args, aur_only=aur_only)
             command.append(package)


### PR DESCRIPTION
Add a new option `use_args` which enables users to pass arbitrary arguments to helpers when they are explicitly specified via `use` for the package-install and upgrade actions.

Closes #38