### PR TITLE
Added `paru` as a helper option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ The following helpers are supported and automatically selected, if present, in t
 - [makepkg](https://wiki.archlinux.org/index.php/makepkg)
 
 ## Options
-|Parameter      |Choices/**Default**                                    |Comments|
-|---            |---                                                    |---|
-|name           |                                                       |Name or list of names of the package(s) to install or upgrade.|
-|state          |**present**, latest                                    |Desired state of the package, 'present' skips operations if the package is already installed.|
-|upgrade        |yes, **no**                                            |Whether or not to upgrade whole system.|
+|Parameter      |Choices/**Default**                                          |Comments|
+|---            |---                                                          |---|
+|name           |                                                             |Name or list of names of the package(s) to install or upgrade.|
+|state          |**present**, latest                                          |Desired state of the package, 'present' skips operations if the package is already installed.|
+|upgrade        |yes, **no**                                                  |Whether or not to upgrade whole system.|
 |use            |**auto**, yay, paru, pacaur, trizen, pikaur, aurman, makepkg |The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.|
-|extra_args     |**null**                                               |A list of additional arguments to pass directly to the tool. Cannot be used in 'auto' mode.|
-|aur_only       |yes, **no**                                            |Limit helper operation to the AUR.|
-|local_pkgbuild |Local directory with PKGBUILD, **null**                |Only valid with makepkg or pikaur. Don't download the package from AUR. Build the package using a local PKGBUILD and the other build files.|
-|skip_pgp_check |yes, **no**                                            |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured.|
-|ignore_arch    |yes, **no**                                            |Only valid with makepkg. Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field.|
+|extra_args     |**null**                                                     |A list of additional arguments to pass directly to the tool. Cannot be used in 'auto' mode.|
+|aur_only       |yes, **no**                                                  |Limit helper operation to the AUR.|
+|local_pkgbuild |Local directory with PKGBUILD, **null**                      |Only valid with makepkg or pikaur. Don't download the package from AUR. Build the package using a local PKGBUILD and the other build files.|
+|skip_pgp_check |yes, **no**                                                  |Only valid with makepkg. Skip PGP signatures verification of source file, useful when installing packages without GnuPG properly configured.|
+|ignore_arch    |yes, **no**                                                  |Only valid with makepkg. Ignore a missing or incomplete arch field, useful when the PKGBUILD does not have the arch=('yourarch') field.|
 
 ### Note
 * Either *name* or *upgrade* is required, both cannot be used together.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ansible module to use some Arch User Repository (AUR) helpers as well as makepkg
 
 The following helpers are supported and automatically selected, if present, in the order listed below:
 - [yay](https://github.com/Jguer/yay)
+- [paru](https://github.com/Morganamilo/paru)
 - [pacaur](https://github.com/E5ten/pacaur)
 - [trizen](https://github.com/trizen/trizen)
 - [pikaur](https://github.com/actionless/pikaur)
@@ -17,7 +18,7 @@ The following helpers are supported and automatically selected, if present, in t
 |name           |                                                       |Name or list of names of the package(s) to install or upgrade.|
 |state          |**present**, latest                                    |Desired state of the package, 'present' skips operations if the package is already installed.|
 |upgrade        |yes, **no**                                            |Whether or not to upgrade whole system.|
-|use            |**auto**, yay, pacaur, trizen, pikaur, aurman, makepkg |The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.|
+|use            |**auto**, yay, paru, pacaur, trizen, pikaur, aurman, makepkg |The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.|
 |extra_args     |**null**                                               |A list of additional arguments to pass directly to the tool. Cannot be used in 'auto' mode.|
 |aur_only       |yes, **no**                                            |Limit helper operation to the AUR.|
 |local_pkgbuild |Local directory with PKGBUILD, **null**                |Only valid with makepkg or pikaur. Don't download the package from AUR. Build the package using a local PKGBUILD and the other build files.|

--- a/library/aur.py
+++ b/library/aur.py
@@ -43,7 +43,7 @@ options:
         description:
             - The tool to use, 'auto' uses the first known helper found and makepkg as a fallback.
         default: auto
-        choices: [ auto, yay, pacaur, trizen, pikaur, aurman, makepkg ]
+        choices: [ auto, yay, paru, pacaur, trizen, pikaur, aurman, makepkg ]
 
     extra_args:
         description:
@@ -104,6 +104,7 @@ def_lang = ['env', 'LC_ALL=C']
 
 use_cmd = {
     'yay': ['yay', '-S', '--noconfirm', '--needed', '--cleanafter'],
+    'paru': ['paru', '-S', '--noconfirm', '--needed', '--cleanafter'],
     'pacaur': ['pacaur', '-S', '--noconfirm', '--noedit', '--needed'],
     'trizen': ['trizen', '-S', '--noconfirm', '--noedit', '--needed'],
     'pikaur': ['pikaur', '-S', '--noconfirm', '--noedit', '--needed'],
@@ -116,7 +117,7 @@ use_cmd_local_pkgbuild = {
     'makepkg': ['makepkg', '--syncdeps', '--install', '--noconfirm', '--needed']
 }
 
-has_aur_option = ['yay', 'pacaur', 'trizen', 'pikaur', 'aurman']
+has_aur_option = ['yay', 'paru', 'pacaur', 'trizen', 'pikaur', 'aurman']
 
 
 def package_installed(module, package):


### PR DESCRIPTION
Added `paru` as an additional AUR helper option, `auto` option just after `yay` was chosen as it accepts all of the same options, being that it is basically a "port" of `yay`.

Addresses issue: https://github.com/kewlfft/ansible-aur/issues/51