### PR TITLE
Fix `ansible-doc aur` error about dictionary element length

### DIFF
--- a/library/aur.py
+++ b/library/aur.py
@@ -90,7 +90,7 @@ RETURN = '''
 msg:
     description: action that has been taken
 helper:
-    the helper that was actually used
+    description: the helper that was actually used
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Fixes the following error when running `ansible-doc aur`:

```
ERROR! Unable to retrieve documentation from 'aur' due to: dictionary
update sequence element #0 has length 1; 2 is required
```

It was because the `helper` value in the `RETURN` section was missing
the `description` key.