### PR TITLE
Fix upgrade changed logic and language definition when using pikaur

### DIFF
--- a/library/aur.py
+++ b/library/aur.py
@@ -100,7 +100,7 @@ EXAMPLES = '''
   become_user: aur_builder
 '''
 
-def_lang = ['env', 'LC_ALL=C']
+def_lang = ['env', 'LC_ALL=C', 'LANGUAGE=C']
 
 use_cmd = {
     'yay': ['yay', '-S', '--noconfirm', '--needed', '--cleanafter'],
@@ -244,7 +244,7 @@ def upgrade(module, use, extra_args, aur_only):
     rc, out, err = module.run_command(command, check_rc=True)
 
     module.exit_json(
-        changed=not (out == '' or 'nothing to do' in out or 'No AUR updates found' in out),
+        changed=not (out == '' or 'nothing to do' in out.lower() or 'No AUR updates found' in out),
         msg='upgraded system',
         helper=use,
     )


### PR DESCRIPTION
Every time I called the module to upgrade my system it would set the status as changed even if I upgraded the whole system with my AUR helper (I use pikaur). This was the raw command output:
```
# sudo -Hsn -u aur_user env LC_ALL=C pikaur -S --noconfirm --noedit --needed --aur -u           
:: Inizio un aggiornamento completo di AUR...
Sto leggendo i database dei pacchetti nel repository...
Sto leggendo il database locale dei pacchetti...
Sto leggendo le informazioni dei pacchetti AUR...    
:: Niente da fare.
```
In my shell I set `LANGUAGE=it:en`, so I think the module should also override LANGUAGE.
One other thing was the capitalization of the last line, `Nothing to do` instead of `nothing to do`, so the check should be made against the output after lower capitalization.

