### PR TITLE
yay doesn't refer to either LC_ALL or LANGUAGE

### DIFF
--- a/library/aur.py
+++ b/library/aur.py
@@ -100,7 +100,7 @@ EXAMPLES = '''
   become_user: aur_builder
 '''
 
-def_lang = ['env', 'LC_ALL=C', 'LANGUAGE=C']
+def_lang = ['env', 'LC_ALL=C', 'LANGUAGE=C', 'LC_MESSAGES=C']
 
 use_cmd = {
     'yay': ['yay', '-S', '--noconfirm', '--needed', '--cleanafter'],


### PR DESCRIPTION
https://github.com/Jguer/yay/blob/5c11c01d853835f24edbfd0a242dc3a73d537547/main.go#L20-L30
yay seems to look at LC_MESSAGES or LANG, so I added LC_MESSAGES=C. Please check.