### PR TITLE
Use become: yes in the example for creating aur_builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ This user can be created in an Ansible task with the following actions:
 
 ```yaml
 - name: Create the `aur_builder` user
+  become: yes
   ansible.builtin.user:
     name: aur_builder
     create_home: yes
     group: wheel
 
 - name: Allow the `aur_builder` user to run `sudo pacman` without a password
+  become: yes
   ansible.builtin.lineinfile:
     path: /etc/sudoers.d/11-install-aur_builder
     line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'


### PR DESCRIPTION
It is my understanding that for creating the `aur_builder` you have to become root; maybe that's something one does in the whole playbook, but if one wants to specify that only when it's needed, the example could be improved as suggested, so that it's self-contained and can be simply copied and pasted.