### PR TITLE
fix for issue #77

### DIFF
--- a/plugins/modules/aur.py
+++ b/plugins/modules/aur.py
@@ -283,7 +283,7 @@ def install_packages(module, packages, use, extra_args, state, skip_pgp_check, i
             command.append(package)
             rc, out, err = module.run_command(command, check_rc=True)
 
-        changed_iter = changed_iter or not (out == '' or '-- skipping' in out or 'nothing to do' in out.lower())
+        changed_iter = changed_iter or not (out == '' or 'up-to-date -- skipping' in out or 'nothing to do' in out.lower())
 
     message = 'installed package(s)' if changed_iter else 'package(s) already installed'
 


### PR DESCRIPTION
yay appears to be the only one of these supported aur helpers that stores the built package and keeps it even after the package has been removed, and then on (re)install outputs ` -> cava-0.8.3-1 already made -- skipping build` where the `-- skipping` in the output makes the changed_iter bool remain False in the current live version, hence the issue.

So a very minor edit here to the `changed_iter` condition `-- skipping` --> `up-to-date -- skipping`. 

I tested this with yay, paru, trizen, pikaur, aurman and makepkg.

To test, I manually installed a package, and then ran the same play as in the issue to test install (with the package already installed), uninstall and reinstall. In every case the output was the desired:

```
TASK [test : Test install] ***************************************************************
ok: [iota]

TASK [test : Remove test package] ********************************************************
--- before
+++ after
@@ -1 +0,0 @@
-cava-0.8.3-1

changed: [iota]

TASK [test : Test reinstall] *************************************************************
changed: [iota]
```

I would have to set up an x86 vm to test pacaur as a dependency failed to build for aarch64. Pacaur hasn't been updated in 5 years though and is unmaintained so I'm not even sure it works anymore.

There might be some extra testing you want to do as I obviously don't know this module particularly well and might have missed something.
