### PR TITLE
Remove hardcoded locale environment variables

### DIFF
--- a/plugins/modules/aur.py
+++ b/plugins/modules/aur.py
@@ -106,7 +106,7 @@ EXAMPLES = '''
   become_user: aur_builder
 '''
 
-def_lang = ['env', 'LC_ALL=C', 'LANGUAGE=C']
+env = ['env']
 
 use_cmd = {
     'yay': ['yay', '-S', '--noconfirm', '--needed', '--cleanafter'],
@@ -161,9 +161,9 @@ def build_command_prefix(use, extra_args, skip_pgp_check=False, ignore_arch=Fals
     Create the prefix of a command that can be used by the install and upgrade functions.
     """
     if local_pkgbuild:
-        command = def_lang + use_cmd_local_pkgbuild[use]
+        command = env + use_cmd_local_pkgbuild[use]
     else:
-        command = def_lang + use_cmd[use]
+        command = env + use_cmd[use]
     if skip_pgp_check:
         command.append('--skippgpcheck')
     if ignore_arch:


### PR DESCRIPTION
[Line 109](https://github.com/kewlfft/ansible-aur/blob/master/plugins/modules/aur.py#L109) hardcodes the environment variable locales to `C`:  

    def_lang = ['env', 'LC_ALL=C', 'LANGUAGE=C']

but this conflicts with certain PKGBUILDs.  

For example when extracting source files of the `sabnzbd` package `bsdtar` would complain:  

    bsdtar: Pathname can't be converted from UTF-8 to current locale.

and fail the playbook.  

The host machine locales were right, with UTF-8.  

So removing the locale variables: `def_lang = ['env']` and using either:  

    environment:
      LC_ALL: en_US.UTF-8
      LANGUAGE: en_US.UTF-8

or nothing made it work.  

Just as a note, setting:  

    environment:
      LC_ALL: C
      LANGUAGE: C

makes it fail again.  

This can be tested with `bsdtar` directly:  
Download the tar.gz source file from <https://aur.archlinux.org/packages/sabnzbd>  

    LC_ALL=C LANGUAGE=C bsdtar xf file.tar.gz

and it should error out.  

Any special reason for keeping it? If anyone needs to specify them,  
like any other env. var, the `environment` key works fine, given the use  
of `env`. And the good thing is that [it can be used at the play, block, or task level](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_environment.html).

