### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v2

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           path: collections/ansible_collections/kewlfft/aur
 
@@ -26,22 +26,10 @@ jobs:
           echo ::set-output name=version::$(awk -F '/' '{print substr($3, 2)}' <<< ${GITHUB_REF})
 
       - name: "Set up Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-
-      - name: Generate cache keys
-        id: keys
-        run: |
-          echo ::set-output name=pip_cache_dir::$(pip cache dir)
-          # This ensures that the cache is invalidated after a week
-          echo ::set-output name=date::$(date +%Y_%g)
-
-      - name: Pip Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.keys.outputs.pip_cache_dir }}
-          key: ansible-pip-${{ steps.keys.outputs.date }}
+          python-version: "3.13"
+          cache: 'pip'
 
       - name: Install pip packages
         run: |

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: |
           [ "$(cat galaxy.yml | grep version: | awk '{print $2}')" = $(awk -F '/' '{print substr($3, 2)}' <<< ${GITHUB_REF}) ] || exit 1
-          echo ::set-output name=version::$(awk -F '/' '{print substr($3, 2)}' <<< ${GITHUB_REF})
+          echo "version=$(awk -F '/' '{print substr($3, 2)}' <<< ${GITHUB_REF})" >> $GITHUB_OUTPUT
 
       - name: "Set up Python"
         uses: actions/setup-python@v5

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -25,18 +25,6 @@ jobs:
           [ "$(cat galaxy.yml | grep version: | awk '{print $2}')" = $(awk -F '/' '{print substr($3, 2)}' <<< ${GITHUB_REF}) ] || exit 1
           echo "version=$(awk -F '/' '{print substr($3, 2)}' <<< ${GITHUB_REF})" >> $GITHUB_OUTPUT
 
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: 'pip'
-
-      - name: Install pip packages
-        run: |
-          pip3 install -U pip
-          pip3 install wheel
-          pip3 install ansible-core
-
       - name: Deploy collection
         run: |
           ansible-galaxy collection build


### PR DESCRIPTION
I noticed that you published `v0.12.0` a few days ago but the collection was never updated on ansible galaxy (https://galaxy.ansible.com/ui/repo/published/kewlfft/aur/ still shows `v0.11.0`). I noticed this is because the Github action that's supposed to publish it timed out waiting for a runner to be available because the workflow was pointing directly to `ubuntu-20.04` which Github stopped supporting some time ago. I updated to use the latest ubuntu version as well as made some other improvements which I hope you find worthwhile. (You'll need to publish a new version for this to actually publish to ansible galaxy but on my fork I ran the action without the publish step to make sure that it was still able to build the collection tarball correctly).

- Updates to use the `ubuntu-latest` runner (currently `ubuntu-24.04`)
- Updates to use the latest checkout action since Github stopped supporting older nodejs runtimes for the actions steps this is necessary
- Removed the python install, and dependency caching - the ansible package is preinstalled in the runner image so we can interact with ansible galaxy (`ansible-galaxy` command) without needing to install any additional packages. This should be fine because all we're doing is building the collection tarball and publishing it (ie no linting or tests or checking against multiple versions etc)
- Fixed the github output for the version check. A while ago Github removed support for the `::set-value` echo syntax in favor of outputting to the `$GITHUB_OUTPUT`.